### PR TITLE
Fix strict compiler options related errors

### DIFF
--- a/Kadabra-JS/src-api/Kadabra.ts
+++ b/Kadabra-JS/src-api/Kadabra.ts
@@ -1,18 +1,17 @@
 import KadabraJavaTypes from "./kadabra/KadabraJavaTypes.js";
 
 export default class Kadabra {
+    /**
+     * Launches a Kadabra weaving session.
+     * @param args - The arguments to pass to the weaver, as if it was launched from the command-line
+     */
+    static readonly runKadabra = function (args: string | Array<string>) {
+        // If string, separate arguments
+        if (typeof args === "string") {
+            args =
+                KadabraJavaTypes.ArgumentsParser.newCommandLine().parse(args);
+        }
 
-  /**
-   * Launches a Kadabra weaving session.
-   * @param {(string|Array)} args - The arguments to pass to the weaver, as if it was launched from the command-line
-   * @return {Boolean} true if the weaver executes without problems, false otherwise
-   */
-  static runKadabra = function (args) {
-    // If string, separate arguments
-    if (typeof args === "string") {
-      args = KadabraJavaTypes.ArgumentsParser.newCommandLine().parse(args);
-    }
-
-    return KadabraJavaTypes.KadabraLauncher.execute(args);
-  };
+        return KadabraJavaTypes.KadabraLauncher.execute(args);
+    };
 }

--- a/Kadabra-JS/src-api/kadabra/analysis/energy/EnergyAwareAndroidPatterns.ts
+++ b/Kadabra-JS/src-api/kadabra/analysis/energy/EnergyAwareAndroidPatterns.ts
@@ -6,6 +6,12 @@ import HashMapUsageDetector from "./detectors/HashMapUsageDetector.js";
 import ExcessiveMethodCallsDetector from "./detectors/ExcessiveMethodCallsDetector.js";
 import BaseDetector from "./detectors/BaseDetector.js";
 
+export interface Report {
+    sources: string[];
+    total: number;
+    detectors: Map<string, string[]>;
+}
+
 export default class EnergyAwareAndroidPatterns {
     debugEnabled: boolean;
     detectors: BaseDetector[];
@@ -40,23 +46,22 @@ export default class EnergyAwareAndroidPatterns {
 
     toReport() {
         const files = WeaverOptions.getData().get("workspace").getFiles();
-        const sources = [];
+        const sources: string[] = [];
         for (const f of files) {
             sources.push(f.toString());
         }
 
-        const results = {};
-        results["sources"] = sources;
-        results["total"] = 0;
-        const data = {};
+        const results: Report = {
+            sources: sources,
+            total: 0,
+            detectors: new Map(),
+        };
 
         for (const d of this.detectors) {
             const res = d.save();
-            data[`${d.name}`] = res;
-            results["total"] += res.length;
+            results.detectors.set(`${d.name}`, res);
+            results.total += res.length;
         }
-
-        results["detectors"] = data;
 
         return results;
     }

--- a/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/BaseDetector.ts
+++ b/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/BaseDetector.ts
@@ -1,9 +1,9 @@
 import Query from "@specs-feup/lara/api/weaver/Query.js";
-import { Call, Class, Joinpoint, Method, New } from "../../../../Joinpoints.js";
+import { Class, Joinpoint } from "../../../../Joinpoints.js";
 
 export default class BaseDetector {
     name: string;
-    results: (Call | New | Method)[];
+    results: Joinpoint[];
     debugEnabled: boolean;
 
     constructor(name: string, debugEnabled = false) {
@@ -27,6 +27,7 @@ export default class BaseDetector {
     }
 
     analyseClass(jpClass: Joinpoint) {
+        jpClass.insert("before", "foo");
         if (
             !jpClass ||
             !("instanceOf" in jpClass) ||

--- a/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/HashMapUsageDetector.ts
+++ b/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/HashMapUsageDetector.ts
@@ -13,7 +13,7 @@ export default class HashMapUsageDetector extends BaseDetector {
 
         const hashMapRefs = Query.searchFrom(jpClass, New, {
             type: "HashMap",
-            typeReference: (jp) => jp?.packageName === "java.util",
+            typeReference: (jp) => jp.packageName === "java.util",
         }).get();
 
         this.results.push(...hashMapRefs);

--- a/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/InternalGetterDetector.ts
+++ b/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/InternalGetterDetector.ts
@@ -13,6 +13,8 @@ import {
 } from "../../../../Joinpoints.js";
 
 export default class InternalGetterDetector extends BaseDetector {
+    results: Call[] = [];
+
     constructor() {
         super("Internal Getter Detector");
     }
@@ -30,7 +32,8 @@ export default class InternalGetterDetector extends BaseDetector {
             .children(Return)
             .children(Var, { isField: true })
             .chain()
-            .map((m) => m["method"]);
+            .map((result) => result["method"])
+            .filter((method) => method !== undefined);
 
         const internalCalls = Query.searchFrom(jpClass, Call, {
             decl: (d) =>
@@ -52,7 +55,7 @@ export default class InternalGetterDetector extends BaseDetector {
     }
 
     save() {
-        return this.results.map((r: Call) => {
+        return this.results.map((r) => {
             let loc = r.name + "(" + r.arguments + "):" + r.line.toString();
 
             // Initialized inside method

--- a/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/MemberIgnoringMethodDetector.ts
+++ b/Kadabra-JS/src-api/kadabra/analysis/energy/detectors/MemberIgnoringMethodDetector.ts
@@ -14,6 +14,7 @@ import {
 
 export default class MemberIgnoringMethodDetector extends BaseDetector {
     dups: Map<string, Method[]>;
+    results: Method[] = [];
 
     constructor() {
         super("Member Ignoring Method Detector");
@@ -125,7 +126,7 @@ export default class MemberIgnoringMethodDetector extends BaseDetector {
     }
 
     #callIsStatic(jpCall: Call) {
-        return jpCall.decl?.isStatic;
+        return jpCall.decl.isStatic;
     }
 
     #varIsStatic(jpVar: Var) {

--- a/Kadabra-JS/src-api/kadabra/monitor/Counter.ts
+++ b/Kadabra-JS/src-api/kadabra/monitor/Counter.ts
@@ -45,6 +45,12 @@ export function CountingMonitor(
     monitorPackage = "pt.up.fe.specs.lara.kadabra.utils"
 ) {
     const monitorClass = GetCountingMonitor(monitorPackage, "CountingMonitor");
+    if (monitorClass === undefined) {
+        throw new Error(
+            "Expected monitorClass to be of type Class but was undefined."
+        );
+    }
+
     let name = "kadabra" + monitorClass.name;
 
     let counter = 0;

--- a/Kadabra-JS/src-api/kadabra/monitor/CounterList.ts
+++ b/Kadabra-JS/src-api/kadabra/monitor/CounterList.ts
@@ -13,6 +13,12 @@ export function CountingMonitorList(
         monitorPackage,
         "CountingMonitorList"
     );
+    if (monitor === undefined) {
+        throw new Error(
+            "Expected monitorClass to be of type Class but was undefined."
+        );
+    }
+
     let name = "kadabra" + monitor.name;
 
     let counter = 0;
@@ -116,9 +122,17 @@ export function NewCountingMonitorList(
     );
     monitorClass.newConstructor(["public"], ["int"], ["size"]);
 
-    Query.searchFrom(monitorClass, Constructor, "increment")
-        .getFirst()
-        .body.insertReplace("counter = new int[size];");
+    const constructor = Query.searchFrom(
+        monitorClass,
+        Constructor,
+        "increment"
+    ).getFirst();
+    if (constructor === undefined) {
+        throw new Error(
+            "Expected constructor to be of type Constructor but was undefined"
+        );
+    }
+    constructor.body.insertReplace("counter = new int[size];");
 
     return monitorClass;
 }

--- a/KadabraLaraApi/src-lara/kadabra/Kadabra.js
+++ b/KadabraLaraApi/src-lara/kadabra/Kadabra.js
@@ -2,13 +2,13 @@ import KadabraJavaTypes from "./kadabra/KadabraJavaTypes.js";
 export default class Kadabra {
     /**
      * Launches a Kadabra weaving session.
-     * @param {(string|Array)} args - The arguments to pass to the weaver, as if it was launched from the command-line
-     * @return {Boolean} true if the weaver executes without problems, false otherwise
+     * @param args - The arguments to pass to the weaver, as if it was launched from the command-line
      */
     static runKadabra = function (args) {
         // If string, separate arguments
         if (typeof args === "string") {
-            args = KadabraJavaTypes.ArgumentsParser.newCommandLine().parse(args);
+            args =
+                KadabraJavaTypes.ArgumentsParser.newCommandLine().parse(args);
         }
         return KadabraJavaTypes.KadabraLauncher.execute(args);
     };

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/EnergyAwareAndroidPatterns.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/EnergyAwareAndroidPatterns.js
@@ -35,16 +35,16 @@ export default class EnergyAwareAndroidPatterns {
         for (const f of files) {
             sources.push(f.toString());
         }
-        const results = {};
-        results["sources"] = sources;
-        results["total"] = 0;
-        const data = {};
+        const results = {
+            sources: sources,
+            total: 0,
+            detectors: new Map(),
+        };
         for (const d of this.detectors) {
             const res = d.save();
-            data[`${d.name}`] = res;
-            results["total"] += res.length;
+            results.detectors.set(`${d.name}`, res);
+            results.total += res.length;
         }
-        results["detectors"] = data;
         return results;
     }
     toJson(path) {

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/BaseDetector.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/BaseDetector.js
@@ -20,6 +20,7 @@ export default class BaseDetector {
         return this;
     }
     analyseClass(jpClass) {
+        jpClass.insert("before", "foo");
         if (!jpClass ||
             !("instanceOf" in jpClass) ||
             !(jpClass instanceof Class)) {

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/ExcessiveMethodCallsDetector.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/ExcessiveMethodCallsDetector.js
@@ -4,12 +4,13 @@ import BaseDetector from "./BaseDetector.js";
 import { Loop, Var, Call, RefType, LoopType, LocalVariable, ArrayAccess, } from "../../../../Joinpoints.js";
 export default class ExcessiveMethodCallsDetector extends BaseDetector {
     currentPackage;
-    loopGlobalReads;
-    loopGlobalWrites;
-    loopLocalWrites;
-    methodsInfo;
-    variantCalls;
-    missingCallDecl;
+    loopGlobalReads = [];
+    loopGlobalWrites = [];
+    loopLocalWrites = [];
+    methodsInfo = [];
+    variantCalls = [];
+    missingCallDecl = false;
+    results = [];
     constructor(debugEnabled = false) {
         super("Excessive Method Calls Detector", debugEnabled);
     }
@@ -261,7 +262,10 @@ export default class ExcessiveMethodCallsDetector extends BaseDetector {
             return false;
         }
         const mi = ExcessiveMethodCallsDetector.tryGetMethodInfo(this.methodsInfo, jpCall.decl);
-        if (mi?.missingInfo) {
+        if (mi === null) {
+            throw new Error("Failed to get MethodInfo");
+        }
+        if (mi.missingInfo) {
             this.printDebugInfo(`Call: ${jpCall} @ L${jpCall.line} -> VARIANT (methodMissingInfo)`);
             this.variantCalls.push(jpCall.toString());
             return false;
@@ -334,6 +338,7 @@ export default class ExcessiveMethodCallsDetector extends BaseDetector {
         if (jp instanceof Call) {
             return !this.isCallInvariant(jp);
         }
+        return false;
     }
     getFirstDescendentsOfTypes(jp, types) {
         if (types.some((type) => jp.instanceOf(type))) {

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/HashMapUsageDetector.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/HashMapUsageDetector.js
@@ -10,7 +10,7 @@ export default class HashMapUsageDetector extends BaseDetector {
         super.analyseClass(jpClass);
         const hashMapRefs = Query.searchFrom(jpClass, New, {
             type: "HashMap",
-            typeReference: (jp) => jp?.packageName === "java.util",
+            typeReference: (jp) => jp.packageName === "java.util",
         }).get();
         this.results.push(...hashMapRefs);
     }

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/InternalGetterDetector.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/InternalGetterDetector.js
@@ -3,6 +3,7 @@ import Collections from "@specs-feup/lara/api/lara/Collections.js";
 import BaseDetector from "./BaseDetector.js";
 import { Body, Call, Method, Return, Var, } from "../../../../Joinpoints.js";
 export default class InternalGetterDetector extends BaseDetector {
+    results = [];
     constructor() {
         super("Internal Getter Detector");
     }
@@ -17,7 +18,8 @@ export default class InternalGetterDetector extends BaseDetector {
             .children(Return)
             .children(Var, { isField: true })
             .chain()
-            .map((m) => m["method"]);
+            .map((result) => result["method"])
+            .filter((method) => method !== undefined);
         const internalCalls = Query.searchFrom(jpClass, Call, {
             decl: (d) => d !== undefined && simpleGetters.some((sg) => sg.equals(d)),
         }).get();

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/MemberIgnoringMethodDetector.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/analysis/energy/detectors/MemberIgnoringMethodDetector.js
@@ -4,6 +4,7 @@ import BaseDetector from "./BaseDetector.js";
 import { Call, Method, Reference, Var, } from "../../../../Joinpoints.js";
 export default class MemberIgnoringMethodDetector extends BaseDetector {
     dups;
+    results = [];
     constructor() {
         super("Member Ignoring Method Detector");
         this.dups = new Map();
@@ -96,7 +97,7 @@ export default class MemberIgnoringMethodDetector extends BaseDetector {
         return true;
     }
     #callIsStatic(jpCall) {
-        return jpCall.decl?.isStatic;
+        return jpCall.decl.isStatic;
     }
     #varIsStatic(jpVar) {
         const isParameter = Query.childrenFrom(jpVar, Reference, { type: "Parameter" }).get()

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/monitor/Counter.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/monitor/Counter.js
@@ -22,6 +22,9 @@ export function NewCounter(jpClass, name = "counter", fullPath = false) {
 }
 export function CountingMonitor(targetClass, targetMethod, targetStmt, location = "before", monitorPackage = "pt.up.fe.specs.lara.kadabra.utils") {
     const monitorClass = GetCountingMonitor(monitorPackage, "CountingMonitor");
+    if (monitorClass === undefined) {
+        throw new Error("Expected monitorClass to be of type Class but was undefined.");
+    }
     let name = "kadabra" + monitorClass.name;
     let counter = 0;
     while (Query.searchFrom(targetClass, Field, {

--- a/KadabraLaraApi/src-lara/kadabra/kadabra/monitor/CounterList.js
+++ b/KadabraLaraApi/src-lara/kadabra/kadabra/monitor/CounterList.js
@@ -5,6 +5,9 @@ import Query from "@specs-feup/lara/api/weaver/Query.js";
 import { Class, Constructor, Field, FileJp } from "../../Joinpoints.js";
 export function CountingMonitorList(targetClass, monitorPackage = "pt.up.fe.specs.lara.kadabra.utils") {
     const monitor = GetCountingMonitorList(monitorPackage, "CountingMonitorList");
+    if (monitor === undefined) {
+        throw new Error("Expected monitorClass to be of type Class but was undefined.");
+    }
     let name = "kadabra" + monitor.name;
     let counter = 0;
     while (Query.searchFrom(targetClass, Field, {
@@ -63,9 +66,11 @@ export function NewCountingMonitorList(packageName, simpleName) {
     monitorClass.newMethod(["public"], "int", "get", ["int"], ["id"], "return counter[id];");
     monitorClass.newMethod(["public"], "void", "reset", ["int"], ["id"], "counter[id] = 0;");
     monitorClass.newConstructor(["public"], ["int"], ["size"]);
-    Query.searchFrom(monitorClass, Constructor, "increment")
-        .getFirst()
-        .body.insertReplace("counter = new int[size];");
+    const constructor = Query.searchFrom(monitorClass, Constructor, "increment").getFirst();
+    if (constructor === undefined) {
+        throw new Error("Expected constructor to be of type Constructor but was undefined");
+    }
+    constructor.body.insertReplace("counter = new int[size];");
     return monitorClass;
 }
 //# sourceMappingURL=CounterList.js.map


### PR DESCRIPTION
Fix strict compiler options related errors in:
- analysis/energy/detectors/BaseDetector.ts
- analysis/energy/detectors/ExcessiveMethodCallsDetector.ts
- analysis/energy/detectors/HashMapUsageDetector.ts
- analysis/energy/detectors/InternalGetterDetector.ts
- analysis/energy/detectors/MemberIgnoringMethodDetector.ts
- analysis/energy/EnergyAwareAndroidPatterns.ts
- monitor/Counter.ts
- monitor/CounterList.ts
- Kadabra.ts